### PR TITLE
Minor fixes and addition of raw angle data

### DIFF
--- a/Sweep/Sweep.cpp
+++ b/Sweep/Sweep.cpp
@@ -60,6 +60,8 @@ bool Sweep::getReading(ScanPacket &reading)
     {
         // TODO: validate receipt
         reading.bIsSync = _responseScanPacket[0] % 2 == 1;
+        reading.rawAngle = _responseScanPacket[2] << 8;
+        reading.rawAngle += _responseScanPacket[1];
         // convert the angle into a float in degrees
         reading.angle = angle_raw_to_deg((_responseScanPacket[2] << 8) + (_responseScanPacket[1]));
         reading.distance = (_responseScanPacket[4] << 8) + (_responseScanPacket[3]);
@@ -80,6 +82,10 @@ bool Sweep::getMotorReady()
         const uint8_t readyCode[2] = {_responseInfoSetting[2], _responseInfoSetting[3]};
         // readyCode == 0 indicates device is ready
         return _ascii_bytes_to_integer(readyCode) == 0;
+    }
+    else
+    {
+      return false;
     }
 }
 
@@ -177,14 +183,14 @@ void Sweep::reset()
     _writeCommand(_RESET_DEVICE);
 }
 
-bool Sweep::_writeCommand(const uint8_t cmd[2])
+void Sweep::_writeCommand(const uint8_t cmd[2])
 {
     const uint8_t command[3] = {cmd[0], cmd[1], _COMMAND_TERMINATION};
 
     _serial.write(command, 3);
 }
 
-bool Sweep::_writeCommandWithArgument(const uint8_t cmd[2], const uint8_t arg[2])
+void Sweep::_writeCommandWithArgument(const uint8_t cmd[2], const uint8_t arg[2])
 {
     const uint8_t command[5] = {cmd[0], cmd[1], arg[0], arg[1], _COMMAND_TERMINATION};
 

--- a/Sweep/Sweep.h
+++ b/Sweep/Sweep.h
@@ -12,6 +12,7 @@
 #define sweepArrLen(x) (sizeof(x) / sizeof(*x))
 
 // Available Motor Speed Codes for the setMotorSpeed method
+const uint8_t MOTOR_SPEED_CODE_0_HZ[2] = {'0', '0'};
 const uint8_t MOTOR_SPEED_CODE_1_HZ[2] = {'0', '1'};
 const uint8_t MOTOR_SPEED_CODE_2_HZ[2] = {'0', '2'};
 const uint8_t MOTOR_SPEED_CODE_3_HZ[2] = {'0', '3'};
@@ -40,6 +41,7 @@ struct ScanPacket
 {
     bool bIsSync;           // 1 -> first reading of new scan, 0 otherwise
     float angle;            // degrees
+	uint16_t rawAngle;      // Fixed point value of angle
     uint16_t distance;      // cm
     uint8_t signalStrength; // 0:255, higher is better
 };
@@ -161,9 +163,9 @@ class Sweep
     uint8_t _responseInfoSetting[5];
 
     // Write command without any argument
-    bool _writeCommand(const uint8_t cmd[2]);
+    void _writeCommand(const uint8_t cmd[2]);
     // Write command with a 2 character argument code
-    bool _writeCommandWithArgument(const uint8_t cmd[2], const uint8_t arg[2]);
+    void _writeCommandWithArgument(const uint8_t cmd[2], const uint8_t arg[2]);
 
     // Read various types of responses
     bool _readResponseHeader();

--- a/Sweep/keywords.txt
+++ b/Sweep/keywords.txt
@@ -26,6 +26,7 @@ reset	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
+MOTOR_SPEED_CODE_0_HZ	LITERAL1
 MOTOR_SPEED_CODE_1_HZ	LITERAL1
 MOTOR_SPEED_CODE_2_HZ	LITERAL1
 MOTOR_SPEED_CODE_3_HZ	LITERAL1


### PR DESCRIPTION
#### Scope of changes

I added the constant for the motor speed of 0 Hz, which was missing.
The 2 boolean methods _writeCommand and _writeCommandWithArgument had no return statements. I changed these to void methods.
The getMotorReady() method had no return statement for the case where readResponseInfoSetting() returns false, so I added a return statement.
I added the data member (uint16_t rawAngle) to (struct DataPacket), because having access to the raw angle data as a fixed point value makes it possible to easily get the integer part of the angle without using floating point calculations.

#### Known Limitations

Same as before