### PR TITLE
Minor changes to the Sweep library

### DIFF
--- a/Sweep/Sweep.cpp
+++ b/Sweep/Sweep.cpp
@@ -81,6 +81,7 @@ bool Sweep::getMotorReady()
         // readyCode == 0 indicates device is ready
         return _ascii_bytes_to_integer(readyCode) == 0;
     }
+    return false;
 }
 
 bool Sweep::waitUntilMotorReady()
@@ -177,14 +178,14 @@ void Sweep::reset()
     _writeCommand(_RESET_DEVICE);
 }
 
-bool Sweep::_writeCommand(const uint8_t cmd[2])
+void Sweep::_writeCommand(const uint8_t cmd[2])
 {
     const uint8_t command[3] = {cmd[0], cmd[1], _COMMAND_TERMINATION};
 
     _serial.write(command, 3);
 }
 
-bool Sweep::_writeCommandWithArgument(const uint8_t cmd[2], const uint8_t arg[2])
+void Sweep::_writeCommandWithArgument(const uint8_t cmd[2], const uint8_t arg[2])
 {
     const uint8_t command[5] = {cmd[0], cmd[1], arg[0], arg[1], _COMMAND_TERMINATION};
 

--- a/Sweep/Sweep.h
+++ b/Sweep/Sweep.h
@@ -12,6 +12,7 @@
 #define sweepArrLen(x) (sizeof(x) / sizeof(*x))
 
 // Available Motor Speed Codes for the setMotorSpeed method
+const uint8_t MOTOR_SPEED_CODE_0_HZ[2] = {'0', '0'};
 const uint8_t MOTOR_SPEED_CODE_1_HZ[2] = {'0', '1'};
 const uint8_t MOTOR_SPEED_CODE_2_HZ[2] = {'0', '2'};
 const uint8_t MOTOR_SPEED_CODE_3_HZ[2] = {'0', '3'};
@@ -161,9 +162,9 @@ class Sweep
     uint8_t _responseInfoSetting[5];
 
     // Write command without any argument
-    bool _writeCommand(const uint8_t cmd[2]);
+    void _writeCommand(const uint8_t cmd[2]);
     // Write command with a 2 character argument code
-    bool _writeCommandWithArgument(const uint8_t cmd[2], const uint8_t arg[2]);
+    void _writeCommandWithArgument(const uint8_t cmd[2], const uint8_t arg[2]);
 
     // Read various types of responses
     bool _readResponseHeader();

--- a/Sweep/keywords.txt
+++ b/Sweep/keywords.txt
@@ -26,6 +26,7 @@ reset	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
+MOTOR_SPEED_CODE_0_HZ	LITERAL1
 MOTOR_SPEED_CODE_1_HZ	LITERAL1
 MOTOR_SPEED_CODE_2_HZ	LITERAL1
 MOTOR_SPEED_CODE_3_HZ	LITERAL1


### PR DESCRIPTION
I removed my previous commit and made a commit which does not include the raw angle changes but includes the other changes I made.

#### Scope of changes

Added motor speed code for 0 Hz
Changed 2 boolean functions (_writeCommand & _writeCommandWithArgument)
 which each had no return statement to void functions
Fixed Sweep::getMotorReady() which had no return statement for the case
 where _readResponseInfoSetting() returns false

#### Known Limitations

Same as before