### PR TITLE
Changed getDistance() to getDistanceCentimeters()

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ uint16_t getAngleRaw() const
 Returns the angle of this reading as the raw 16-bit fixed point value. The scaling factor of this value is 16; this means that the angle in degrees is obtained by dividing the raw value by 16.
 
 ```c++
-uint16_t getDistance() const
+uint16_t getDistanceCentimeters() const
 ```
 
 Returns the distance of this reading, in centimeters.

--- a/Sweep/Examples/MegaDistanceBlink/MegaDistanceBlink.ino
+++ b/Sweep/Examples/MegaDistanceBlink/MegaDistanceBlink.ino
@@ -192,11 +192,12 @@ bool gatherDistanceInfo()
     if (reading.getAngleDegrees() > 360 - FOV)
     {
       // only consider valid readings (sensor will report distance of 1 for failed readings)
-      if (reading.getDistance() > 1)
+      uint16_t dist = reading.getDistanceCentimeters();
+      if (dist > 1)
       {
         // check if this reading is closer than anything seen so far
-        if (reading.getDistance() < closestDistanceInSpecifiedFOV)
-          closestDistanceInSpecifiedFOV = reading.getDistance();
+        if (dist < closestDistanceInSpecifiedFOV)
+          closestDistanceInSpecifiedFOV = dist;
       }
     }
   }

--- a/Sweep/Examples/MegaSerialPrinter/MegaSerialPrinter.ino
+++ b/Sweep/Examples/MegaSerialPrinter/MegaSerialPrinter.ino
@@ -206,7 +206,7 @@ void gatherSensorReading()
     // store the info for this sample
     syncValues[sampleCount] = reading.isSync();
     angles[sampleCount] = reading.getAngleDegrees();
-    distances[sampleCount] = reading.getDistance();
+    distances[sampleCount] = reading.getDistanceCentimeters();
     signalStrengths[sampleCount] = reading.getSignalStrength();
 
     // increment sample count

--- a/Sweep/ScanPacket.cpp
+++ b/Sweep/ScanPacket.cpp
@@ -20,7 +20,7 @@ uint16_t ScanPacket::getAngleRaw() const
     return _rawAngle;
 }
 
-uint16_t ScanPacket::getDistance() const
+uint16_t ScanPacket::getDistanceCentimeters() const
 {
     return _distance;
 }

--- a/Sweep/ScanPacket.h
+++ b/Sweep/ScanPacket.h
@@ -22,8 +22,8 @@ class ScanPacket
     // Returns the angle as a raw fixed point value
     uint16_t getAngleRaw() const;
 
-    // Returns the range measurement
-    uint16_t getDistance() const;
+    // Returns the range measurement in centimeters
+    uint16_t getDistanceCentimeters() const;
 
     // Returns the signal strength as an integer value between 0 and 255
     uint8_t getSignalStrength() const;

--- a/Sweep/keywords.txt
+++ b/Sweep/keywords.txt
@@ -26,7 +26,7 @@ reset	KEYWORD2
 isSync	KEYWORD2
 getAngleDegrees	KEYWORD2
 getAngleRaw	KEYWORD2
-getDistance	KEYWORD2
+getDistanceCentimeters	KEYWORD2
 getSignalStrength	KEYWORD2
 
 #######################################


### PR DESCRIPTION
#### Scope of changes

Changed the name of the ScanPacket method getDistance() to
getDistanceCentimeters() to indicate the unit of measurement of the
returned value. This name is also parallel with the method
getAngleDegrees(). Also, updated keywords.txt, the readme, and the
Arduino sketches accordingly.

#### Known Limitations

I made sure that the Arduino sketches compile, but I haven't officially tested them with a Sweep and Arduino.