### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/Sweep/keywords.txt
+++ b/Sweep/keywords.txt
@@ -6,7 +6,7 @@
 # Datatypes (KEYWORD1)
 #######################################
 Sweep	KEYWORD1
-ScanPacket	ScanPacket
+ScanPacket	KEYWORD1
 
 #######################################
 # Methods and functions (KEYWORD2)

--- a/Sweep/keywords.txt
+++ b/Sweep/keywords.txt
@@ -11,7 +11,7 @@ ScanPacket	KEYWORD1
 #######################################
 # Methods and functions (KEYWORD2)
 #######################################
-isScanning  KEYWORD2
+isScanning	KEYWORD2
 startScanning	KEYWORD2
 stopScanning	KEYWORD2
 getReading	KEYWORD2


### PR DESCRIPTION
- Correct invalid KEYWORD_TOKENTYPE.
- Use correct field separator.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords